### PR TITLE
Add support for cluster label in alerts

### DIFF
--- a/alerts/alerts.libsonnet
+++ b/alerts/alerts.libsonnet
@@ -94,7 +94,7 @@
                 cluster_autoscaler_max_nodes_count{%(clusterAutoscalerSelector)s}
               ) by (%(clusterLabel)s, namespace, job)
               * 100 > %(nodeCountCapacityThreshold)s
-            ||| % $._config,
+            ||| % {clusterLabel: $._config.clusterLabel, clusterAutoscalerSelector: $._config.clusterAutoscaler.clusterAutoscalerSelector},
             'for': '15m',
             labels: {
               severity: 'warning',
@@ -112,7 +112,7 @@
                 cluster_autoscaler_unschedulable_pods_count{%(clusterAutoscalerSelector)s}
               ) by (%(clusterLabel)s, namespace, job)
               > 0
-            ||| % $._config,
+            ||| % {clusterLabel: $._config.clusterLabel, clusterAutoscalerSelector: $._config.clusterAutoscaler.clusterAutoscalerSelector},
             'for': '15m',
             labels: {
               severity: 'warning',

--- a/alerts/alerts.libsonnet
+++ b/alerts/alerts.libsonnet
@@ -94,7 +94,7 @@
                 cluster_autoscaler_max_nodes_count{%(clusterAutoscalerSelector)s}
               ) by (%(clusterLabel)s, namespace, job)
               * 100 > %(nodeCountCapacityThreshold)s
-            ||| % {clusterLabel: $._config.clusterLabel, clusterAutoscalerSelector: $._config.clusterAutoscaler.clusterAutoscalerSelector},
+            ||| % {clusterLabel: $._config.clusterLabel, clusterAutoscalerSelector: $._config.clusterAutoscaler.clusterAutoscalerSelector, nodeCountCapacityThreshold: $._config.clusterAutoscaler.nodeCountCapacityThreshold},
             'for': '15m',
             labels: {
               severity: 'warning',

--- a/prometheus_alerts.yaml
+++ b/prometheus_alerts.yaml
@@ -13,7 +13,7 @@
             job=~"karpenter"
           }[5m]
         )
-      ) by (namespace, job, provider, controller, method) > 0
+      ) by (cluster, namespace, job, provider, controller, method) > 0
     "for": "5m"
     "labels":
       "severity": "warning"
@@ -27,13 +27,13 @@
         karpenter_nodeclaims_termination_duration_seconds_sum{
           job=~"karpenter"
         }
-      ) by (namespace, job, nodepool)
+      ) by (cluster, namespace, job, nodepool)
       /
       sum(
         karpenter_nodeclaims_termination_duration_seconds_count{
           job=~"karpenter"
         }
-      ) by (namespace, job, nodepool) > 1200
+      ) by (cluster, namespace, job, nodepool) > 1200
     "for": "15m"
     "labels":
       "severity": "warning"
@@ -45,11 +45,11 @@
     "expr": |
       sum (
         karpenter_nodepools_usage{job=~"karpenter"}
-      ) by (namespace, job, nodepool, resource_type)
+      ) by (cluster, namespace, job, nodepool, resource_type)
       /
       sum (
         karpenter_nodepools_limit{job=~"karpenter"}
-      ) by (namespace, job, nodepool, resource_type)
+      ) by (cluster, namespace, job, nodepool, resource_type)
       * 100 > 75
     "for": "15m"
     "labels":
@@ -64,11 +64,11 @@
     "expr": |
       sum (
         cluster_autoscaler_nodes_count{job=~"cluster-autoscaler"}
-      ) by (namespace, job)
+      ) by (cluster, namespace, job)
       /
       sum (
         cluster_autoscaler_max_nodes_count{job=~"cluster-autoscaler"}
-      ) by (namespace, job)
+      ) by (cluster, namespace, job)
       * 100 > 75
     "for": "15m"
     "labels":
@@ -81,7 +81,7 @@
     "expr": |
       sum (
         cluster_autoscaler_unschedulable_pods_count{job=~"cluster-autoscaler"}
-      ) by (namespace, job)
+      ) by (cluster, namespace, job)
       > 0
     "for": "15m"
     "labels":


### PR DESCRIPTION
Add support for cluster label to cluster-autoscaler alerts.

Right now the alert aggregate all cluster together which does not work when you have multiple cluster.

This is inspired of https://github.com/adinhodovic/ingress-nginx-mixin/blob/main/alerts/alerts.libsonnet