### PR TITLE
Don't alert on expected Karpenter cloudprovider errors

### DIFF
--- a/alerts/alerts.libsonnet
+++ b/alerts/alerts.libsonnet
@@ -13,7 +13,7 @@
               sum(
                 increase(
                   karpenter_cloudprovider_errors_total{
-                    %(karpenterSelector)s
+                    %(karpenterSelector)s, controller!~"nodeclaim.termination|node.termination", error!="NodeClaimNotFoundError"
                   }[5m]
                 )
               ) by (%(clusterLabel)s, namespace, job, provider, controller, method) > 0

--- a/prometheus_alerts.yaml
+++ b/prometheus_alerts.yaml
@@ -10,7 +10,7 @@
       sum(
         increase(
           karpenter_cloudprovider_errors_total{
-            job=~"karpenter"
+            job=~"karpenter", controller!~"nodeclaim.termination|node.termination", error!="NodeClaimNotFoundError"
           }[5m]
         )
       ) by (cluster, namespace, job, provider, controller, method) > 0

--- a/tests.yaml
+++ b/tests.yaml
@@ -7,7 +7,7 @@ tests:
   # Karpenter
   - interval: 1m
     input_series:
-      - series: 'karpenter_cloudprovider_errors_total{namespace="karpenter", job="karpenter", provider="aws", controller="node.termination", method="Get"}'
+      - series: 'karpenter_cloudprovider_errors_total{namespace="karpenter", job="karpenter", provider="aws", controller="nodeclaim.disruption", method="Get"}'
         values: "1+1x20"
     alert_rule_test:
       - eval_time: 20m
@@ -17,12 +17,12 @@ tests:
               namespace: karpenter
               job: karpenter
               provider: aws
-              controller: node.termination
+              controller: nodeclaim.disruption
               method: Get
               severity: warning
             exp_annotations:
               summary: "Karpenter has Cloud Provider Errors."
-              description: "The Karpenter provider aws with the controller node.termination has errors with the method Get."
+              description: "The Karpenter provider aws with the controller nodeclaim.disruption has errors with the method Get."
               dashboard_url: "https://grafana.com/d/kubernetes-autoscaling-mixin-kperf-jkwq/kubernetes-autoscaling-karpenter-performance"
   - interval: 1m
     input_series:


### PR DESCRIPTION
The Karpenter v1 migration docs[1] say:

> Karpenter now waits for the underlying instance to be completely terminated before deleting a node and orchestrates this by emitting NodeClaimNotFoundError. With this change we expect to see an increase in the NodeClaimNotFoundError. Customers can filter out this error by label in order to get accurate values for karpenter_cloudprovider_errors_total metric. Use this Prometheus filter expression - ({controller!="node.termination"} or {controller!="nodeclaim.termination"}) and {error!="NodeClaimNotFoundError"}.

This change removes alerts for these expected errors.

1: https://karpenter.sh/v1.0/upgrading/v1-migration