### PR TITLE
feat: allow VPA comparison across cluster

### DIFF
--- a/config.libsonnet
+++ b/config.libsonnet
@@ -31,6 +31,8 @@ local annotation = g.dashboard.annotation;
 
     vpa: {
       enabled: true,
+      // Optional: If you want to aggregate the VPA by cluster, set it to true requires showMultiCluster to be true.
+      clusterAggregation: false,
       // Optional: If your VPA names are not based only from the pod name and include a prefix, set it here.
       vpaPrefix: '',
     },

--- a/dashboards/kubernetes/kubernetes-autoscaling-vpa.libsonnet
+++ b/dashboards/kubernetes/kubernetes-autoscaling-vpa.libsonnet
@@ -37,7 +37,7 @@ local tbOverride = tbStandardOptions.override;
 {
   grafanaDashboards+:: std.prune({
 
-    local byCluster(labels) = {'clusterByLabel': if $._config.vpa.clusterAggregation then 'cluster, ' else ''} + labels,
+    local byCluster(labels) = { clusterByLabel: if $._config.vpa.clusterAggregation then 'cluster, ' else '' } + labels,
 
     local datasourceVariable =
       datasource.new(
@@ -65,15 +65,15 @@ local tbOverride = tbStandardOptions.override;
       query.refresh.onTime() +
       (
         if $._config.showMultiCluster then
-        (
+          (
             if $._config.vpa.clusterAggregation then
-            (
-              query.generalOptions.showOnDashboard.withLabelAndValue() +
-              query.withSort(1) +
-              query.selectionOptions.withMulti(true)
-            )
+              (
+                query.generalOptions.showOnDashboard.withLabelAndValue() +
+                query.withSort(1) +
+                query.selectionOptions.withMulti(true)
+              )
             else query.generalOptions.showOnDashboard.withLabelAndValue()
-        )
+          )
         else query.generalOptions.showOnDashboard.withNothing()
       ),
 
@@ -243,27 +243,27 @@ local tbOverride = tbStandardOptions.override;
         tbQueryOptions.transformation.withOptions(
           {
             renameByName: {
-              verticalpodautoscaler: 'Vertical Pod Autoscaler',
-              container: 'Container',
-              resource: 'Resource',
-              'Value #A': 'Requests',
-              'Value #B': 'Limits',
-              'Value #C': 'Lower Bound',
-              'Value #D': 'Target',
-              'Value #E': 'Upper Bound',
-            } +
-            if $._config.vpa.clusterAggregation then {cluster: 'Cluster'} else {},
+                            verticalpodautoscaler: 'Vertical Pod Autoscaler',
+                            container: 'Container',
+                            resource: 'Resource',
+                            'Value #A': 'Requests',
+                            'Value #B': 'Limits',
+                            'Value #C': 'Lower Bound',
+                            'Value #D': 'Target',
+                            'Value #E': 'Upper Bound',
+                          } +
+                          if $._config.vpa.clusterAggregation then { cluster: 'Cluster' } else {},
             indexByName: {
-              verticalpodautoscaler: 1,
-              container: 2,
-              resource: 3,
-              'Value #A': 4,
-              'Value #B': 5,
-              'Value #C': 6,
-              'Value #D': 7,
-              'Value #E': 8,
-            } +
-            if $._config.vpa.clusterAggregation then {cluster: 0} else {},
+                           verticalpodautoscaler: 1,
+                           container: 2,
+                           resource: 3,
+                           'Value #A': 4,
+                           'Value #B': 5,
+                           'Value #C': 6,
+                           'Value #D': 7,
+                           'Value #E': 8,
+                         } +
+                         if $._config.vpa.clusterAggregation then { cluster: 0 } else {},
             excludeByName: {
               Time: true,
               job: true,
@@ -376,27 +376,27 @@ local tbOverride = tbStandardOptions.override;
         tbQueryOptions.transformation.withOptions(
           {
             renameByName: {
-              verticalpodautoscaler: 'Vertical Pod Autoscaler',
-              container: 'Container',
-              resource: 'Resource',
-              'Value #A': 'Requests',
-              'Value #B': 'Limits',
-              'Value #C': 'Lower Bound',
-              'Value #D': 'Target',
-              'Value #E': 'Upper Bound',
-            } +
-            if $._config.vpa.clusterAggregation then {cluster: 'Cluster'} else {},
+                            verticalpodautoscaler: 'Vertical Pod Autoscaler',
+                            container: 'Container',
+                            resource: 'Resource',
+                            'Value #A': 'Requests',
+                            'Value #B': 'Limits',
+                            'Value #C': 'Lower Bound',
+                            'Value #D': 'Target',
+                            'Value #E': 'Upper Bound',
+                          } +
+                          if $._config.vpa.clusterAggregation then { cluster: 'Cluster' } else {},
             indexByName: {
-              verticalpodautoscaler: 1,
-              container: 2,
-              resource: 3,
-              'Value #A': 4,
-              'Value #B': 5,
-              'Value #C': 6,
-              'Value #D': 7,
-              'Value #E': 8,
-            } +
-            if $._config.vpa.clusterAggregation then {cluster: 0} else {},
+                           verticalpodautoscaler: 1,
+                           container: 2,
+                           resource: 3,
+                           'Value #A': 4,
+                           'Value #B': 5,
+                           'Value #C': 6,
+                           'Value #D': 7,
+                           'Value #E': 8,
+                         } +
+                         if $._config.vpa.clusterAggregation then { cluster: 0 } else {},
             excludeByName: {
               namespace: true,
               Time: true,

--- a/dashboards/kubernetes/kubernetes-autoscaling-vpa.libsonnet
+++ b/dashboards/kubernetes/kubernetes-autoscaling-vpa.libsonnet
@@ -474,6 +474,8 @@ local tbOverride = tbStandardOptions.override;
     ||| % byCluster($._config),
     local vpaCpuLimitOverTimeQuery = std.strReplace(vpaCpuRequestOverTimeQuery, 'requests', 'limits'),
 
+    local clusterInLegend(str) = if $._config.vpa.clusterAggregation then '{{cluster}} ' + str else str,
+
     local vpaCpuRecommendationOverTimeTimeSeriesPanel =
       timeSeriesPanel.new(
         'VPA CPU Recommendations Over Time',
@@ -485,42 +487,42 @@ local tbOverride = tbStandardOptions.override;
             vpaCpuRecommendationLowerBoundOverTimeQuery,
           ) +
           prometheus.withLegendFormat(
-            '{{ container }} - Lower Bound'
+            clusterInLegend('Lower Bound')
           ),
           prometheus.new(
             '$datasource',
             vpaCpuRecommendationTargetOverTimeQuery,
           ) +
           prometheus.withLegendFormat(
-            '{{ container }} - Target'
+            clusterInLegend('Target')
           ),
           prometheus.new(
             '$datasource',
             vpaCpuRecommendationUpperBoundOverTimeQuery,
           ) +
           prometheus.withLegendFormat(
-            '{{ container }} - Upper Bound'
+            clusterInLegend('Upper Bound')
           ),
           prometheus.new(
             '$datasource',
             vpaCpuUsageOverTimeQuery,
           ) +
           prometheus.withLegendFormat(
-            '{{ container }} - Usage'
+            clusterInLegend('Usage')
           ),
           prometheus.new(
             '$datasource',
             vpaCpuRequestOverTimeQuery,
           ) +
           prometheus.withLegendFormat(
-            '{{ container }} - Requests'
+            clusterInLegend('Requests')
           ),
           prometheus.new(
             '$datasource',
             vpaCpuLimitOverTimeQuery,
           ) +
           prometheus.withLegendFormat(
-            '{{ container }} - Limits'
+            clusterInLegend('Limits')
           ),
         ]
       ) +
@@ -562,42 +564,42 @@ local tbOverride = tbStandardOptions.override;
             vpaMemoryRecommendationLowerBoundOverTimeQuery,
           ) +
           prometheus.withLegendFormat(
-            '{{ container }} - Lower Bound'
+            clusterInLegend('Lower Bound')
           ),
           prometheus.new(
             '$datasource',
             vpaMemoryRecommendationTargetOverTimeQuery,
           ) +
           prometheus.withLegendFormat(
-            '{{ container }} - Target'
+            clusterInLegend('Target')
           ),
           prometheus.new(
             '$datasource',
             vpaMemoryRecommendationUpperBoundOverTimeQuery,
           ) +
           prometheus.withLegendFormat(
-            '{{ container }} - Upper Bound'
+            clusterInLegend('Upper Bound')
           ),
           prometheus.new(
             '$datasource',
             vpaMemoryUsageOverTimeQuery,
           ) +
           prometheus.withLegendFormat(
-            '{{ container }} - Usage'
+            clusterInLegend('Usage')
           ),
           prometheus.new(
             '$datasource',
             vpaMemoryRequestOverTimeQuery,
           ) +
           prometheus.withLegendFormat(
-            '{{ container }} - Requests'
+            clusterInLegend('Requests')
           ),
           prometheus.new(
             '$datasource',
             vpaMemoryLimitOverTimeQuery,
           ) +
           prometheus.withLegendFormat(
-            '{{ container }} - Limits'
+            clusterInLegend('Limits')
           ),
         ]
       ) +
@@ -622,14 +624,14 @@ local tbOverride = tbStandardOptions.override;
           vpaCpuRecommendationTargetOverTimeQuery
         ) +
         prometheus.withLegendFormat(
-          'CPU Requests'
+          clusterInLegend('CPU Requests')
         ),
         prometheus.new(
           '$datasource',
           vpaCpuRecommendationTargetOverTimeQuery
         ) +
         prometheus.withLegendFormat(
-          'CPU Limits'
+          clusterInLegend('CPU Limits')
         ),
       ]) +
       stStandardOptions.withUnit('short') +
@@ -649,14 +651,14 @@ local tbOverride = tbStandardOptions.override;
           vpaCpuRecommendationLowerBoundOverTimeQuery
         ) +
         prometheus.withLegendFormat(
-          'CPU Requests'
+          clusterInLegend('CPU Requests')
         ),
         prometheus.new(
           '$datasource',
           vpaCpuRecommendationUpperBoundOverTimeQuery
         ) +
         prometheus.withLegendFormat(
-          'CPU Limits'
+          clusterInLegend('CPU Limits')
         ),
       ]) +
       stStandardOptions.withUnit('short') +
@@ -684,14 +686,14 @@ local tbOverride = tbStandardOptions.override;
           vpaMemoryRecommendationTargetOverTimeQuery
         ) +
         prometheus.withLegendFormat(
-          'Memory Requests'
+          clusterInLegend('Memory Requests')
         ),
         prometheus.new(
           '$datasource',
           vpaMemoryRecommendationTargetOverTimeQuery
         ) +
         prometheus.withLegendFormat(
-          'Memory Limits'
+          clusterInLegend('Memory Limits')
         ),
       ]) +
       stStandardOptions.withUnit('bytes') +
@@ -711,14 +713,14 @@ local tbOverride = tbStandardOptions.override;
           vpaMemoryRecommendationLowerBoundOverTimeQuery
         ) +
         prometheus.withLegendFormat(
-          'Memory Requests'
+          clusterInLegend('Memory Requests')
         ),
         prometheus.new(
           '$datasource',
           vpaMemoryRecommendationUpperBoundOverTimeQuery
         ) +
         prometheus.withLegendFormat(
-          'Memory Limits'
+          clusterInLegend('Memory Limits')
         ),
       ]) +
       stStandardOptions.withUnit('bytes') +

--- a/dashboards/kubernetes/kubernetes-autoscaling-vpa.libsonnet
+++ b/dashboards/kubernetes/kubernetes-autoscaling-vpa.libsonnet
@@ -169,28 +169,34 @@ local tbOverride = tbStandardOptions.override;
     local vpaCpuRecommendationLowerBoundQuery = std.strReplace(vpaCpuRecommendationTargetQuery, 'target', 'lowerbound'),
     local vpaCpuRecommendationUpperBoundQuery = std.strReplace(vpaCpuRecommendationTargetQuery, 'target', 'upperbound'),
 
-    local vpaTableRenameByName = {
-      cluster: if $._config.vpa.clusterAggregation then 'Cluster' else null,
-      verticalpodautoscaler: 'Vertical Pod Autoscaler',
-      container: 'Container',
-      resource: 'Resource',
-      'Value #A': 'Requests',
-      'Value #B': 'Limits',
-      'Value #C': 'Lower Bound',
-      'Value #D': 'Target',
-      'Value #E': 'Upper Bound',
-    },
-
-    local vpaTableIndexByName = {
-      cluster: if $._config.vpa.clusterAggregation then 0 else null,
-      verticalpodautoscaler: 1,
-      container: 2,
-      resource: 3,
-      'Value #A': 4,
-      'Value #B': 5,
-      'Value #C': 6,
-      'Value #D': 7,
-      'Value #E': 8,
+    local vpaTableTransformationOptions = {
+      renameByName: {
+        cluster: if $._config.vpa.clusterAggregation then 'Cluster' else null,
+        verticalpodautoscaler: 'Vertical Pod Autoscaler',
+        container: 'Container',
+        resource: 'Resource',
+        'Value #A': 'Requests',
+        'Value #B': 'Limits',
+        'Value #C': 'Lower Bound',
+        'Value #D': 'Target',
+        'Value #E': 'Upper Bound',
+      },
+      indexByName: {
+        cluster: if $._config.vpa.clusterAggregation then 0 else null,
+        verticalpodautoscaler: 1,
+        container: 2,
+        resource: 3,
+        'Value #A': 4,
+        'Value #B': 5,
+        'Value #C': 6,
+        'Value #D': 7,
+        'Value #E': 8,
+      },
+      excludeByName: {
+        Time: true,
+        job: true,
+        namespace: true,
+      },
     },
 
     local vpaCpuResourceTable =
@@ -258,17 +264,7 @@ local tbOverride = tbStandardOptions.override;
         tbQueryOptions.transformation.withId(
           'organize'
         ) +
-        tbQueryOptions.transformation.withOptions(
-          {
-            renameByName: vpaTableRenameByName,
-            indexByName: vpaTableIndexByName,
-            excludeByName: {
-              Time: true,
-              job: true,
-              namespace: true,
-            },
-          }
-        ),
+        tbQueryOptions.transformation.withOptions(vpaTableTransformationOptions),
       ]) +
       tbStandardOptions.withOverrides([
         tbOverride.byName.new('Lower Bound') +
@@ -371,17 +367,7 @@ local tbOverride = tbStandardOptions.override;
         tbQueryOptions.transformation.withId(
           'organize'
         ) +
-        tbQueryOptions.transformation.withOptions(
-          {
-            renameByName: vpaTableRenameByName,
-            indexByName: vpaTableIndexByName,
-            excludeByName: {
-              namespace: true,
-              Time: true,
-              job: true,
-            },
-          }
-        ),
+        tbQueryOptions.transformation.withOptions(vpaTableTransformationOptions),
       ]) +
       tbStandardOptions.withOverrides([
         tbOverride.byName.new('Lower Bound') +

--- a/dashboards_out/kubernetes-autoscaling-mixin-vpa.json
+++ b/dashboards_out/kubernetes-autoscaling-mixin-vpa.json
@@ -133,7 +133,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  label_replace(\n    max(\n      kube_pod_container_resource_requests{\n        cluster=\"$cluster\",\n        job=~\"$job\",\n        namespace=~\"$namespace\",\n        resource=\"cpu\"\n      }\n    ) by (job, namespace, pod, container, resource),\n    \"verticalpodautoscaler\", \"$1\", \"pod\", \"^(.*?)(?:-[a-f0-9]{8,10}-[a-z0-9]{5}|-[0-9]+|-[a-z0-9]{5,16})$\"\n  )\n  + on(job, namespace, container, resource, verticalpodautoscaler) group_left()\n  0 *\n  max(\n    kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n      cluster=\"$cluster\",\n      job=~\"$job\",\n      namespace=~\"$namespace\",\n      resource=\"cpu\"\n    }\n  ) by (job, namespace, verticalpodautoscaler, container, resource)\n)\nby (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  label_replace(\n    max(\n      kube_pod_container_resource_requests{\n        cluster=~\"$cluster\",\n        job=~\"$job\",\n        namespace=~\"$namespace\",\n        resource=\"cpu\"\n      }\n    ) by (job, namespace, pod, container, resource),\n    \"verticalpodautoscaler\", \"$1\", \"pod\", \"^(.*?)(?:-[a-f0-9]{8,10}-[a-z0-9]{5}|-[0-9]+|-[a-z0-9]{5,16})$\"\n  )\n  + on(job, namespace, container, resource, verticalpodautoscaler) group_left()\n  0 *\n  max(\n    kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n      cluster=~\"$cluster\",\n      job=~\"$job\",\n      namespace=~\"$namespace\",\n      resource=\"cpu\"\n    }\n  ) by (job, namespace, verticalpodautoscaler, container, resource)\n)\nby (job, namespace, verticalpodautoscaler, container, resource)\n",
                "format": "table",
                "instant": true,
                "legendFormat": "Requests"
@@ -143,7 +143,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  label_replace(\n    max(\n      kube_pod_container_resource_limits{\n        cluster=\"$cluster\",\n        job=~\"$job\",\n        namespace=~\"$namespace\",\n        resource=\"cpu\"\n      }\n    ) by (job, namespace, pod, container, resource),\n    \"verticalpodautoscaler\", \"$1\", \"pod\", \"^(.*?)(?:-[a-f0-9]{8,10}-[a-z0-9]{5}|-[0-9]+|-[a-z0-9]{5,16})$\"\n  )\n  + on(job, namespace, container, resource, verticalpodautoscaler) group_left()\n  0 *\n  max(\n    kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n      cluster=\"$cluster\",\n      job=~\"$job\",\n      namespace=~\"$namespace\",\n      resource=\"cpu\"\n    }\n  ) by (job, namespace, verticalpodautoscaler, container, resource)\n)\nby (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  label_replace(\n    max(\n      kube_pod_container_resource_limits{\n        cluster=~\"$cluster\",\n        job=~\"$job\",\n        namespace=~\"$namespace\",\n        resource=\"cpu\"\n      }\n    ) by (job, namespace, pod, container, resource),\n    \"verticalpodautoscaler\", \"$1\", \"pod\", \"^(.*?)(?:-[a-f0-9]{8,10}-[a-z0-9]{5}|-[0-9]+|-[a-z0-9]{5,16})$\"\n  )\n  + on(job, namespace, container, resource, verticalpodautoscaler) group_left()\n  0 *\n  max(\n    kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n      cluster=~\"$cluster\",\n      job=~\"$job\",\n      namespace=~\"$namespace\",\n      resource=\"cpu\"\n    }\n  ) by (job, namespace, verticalpodautoscaler, container, resource)\n)\nby (job, namespace, verticalpodautoscaler, container, resource)\n",
                "format": "table",
                "instant": true,
                "legendFormat": "Limits"
@@ -153,7 +153,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound{\n    cluster=\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
                "format": "table",
                "instant": true,
                "legendFormat": "Lower Bound"
@@ -163,7 +163,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n    cluster=\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
                "format": "table",
                "instant": true,
                "legendFormat": "Target"
@@ -173,7 +173,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound{\n    cluster=\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
                "format": "table",
                "instant": true,
                "legendFormat": "Upper Bound"
@@ -193,14 +193,14 @@
                      "namespace": true
                   },
                   "indexByName": {
-                     "Value #A": 3,
-                     "Value #B": 4,
-                     "Value #C": 5,
-                     "Value #D": 6,
-                     "Value #E": 7,
-                     "container": 1,
-                     "resource": 2,
-                     "verticalpodautoscaler": 0
+                     "Value #A": 4,
+                     "Value #B": 5,
+                     "Value #C": 6,
+                     "Value #D": 7,
+                     "Value #E": 8,
+                     "container": 2,
+                     "resource": 3,
+                     "verticalpodautoscaler": 1
                   },
                   "renameByName": {
                      "Value #A": "Requests",
@@ -319,7 +319,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  label_replace(\n    max(\n      kube_pod_container_resource_requests{\n        cluster=\"$cluster\",\n        job=~\"$job\",\n        namespace=~\"$namespace\",\n        resource=\"memory\"\n      }\n    ) by (job, namespace, pod, container, resource),\n    \"verticalpodautoscaler\", \"$1\", \"pod\", \"^(.*?)(?:-[a-f0-9]{8,10}-[a-z0-9]{5}|-[0-9]+|-[a-z0-9]{5,16})$\"\n  )\n  + on(job, namespace, container, resource, verticalpodautoscaler) group_left()\n  0 *\n  max(\n    kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n      cluster=\"$cluster\",\n      job=~\"$job\",\n      namespace=~\"$namespace\",\n      resource=\"memory\"\n    }\n  ) by (job, namespace, verticalpodautoscaler, container, resource)\n)\nby (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  label_replace(\n    max(\n      kube_pod_container_resource_requests{\n        cluster=~\"$cluster\",\n        job=~\"$job\",\n        namespace=~\"$namespace\",\n        resource=\"memory\"\n      }\n    ) by (job, namespace, pod, container, resource),\n    \"verticalpodautoscaler\", \"$1\", \"pod\", \"^(.*?)(?:-[a-f0-9]{8,10}-[a-z0-9]{5}|-[0-9]+|-[a-z0-9]{5,16})$\"\n  )\n  + on(job, namespace, container, resource, verticalpodautoscaler) group_left()\n  0 *\n  max(\n    kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n      cluster=~\"$cluster\",\n      job=~\"$job\",\n      namespace=~\"$namespace\",\n      resource=\"memory\"\n    }\n  ) by (job, namespace, verticalpodautoscaler, container, resource)\n)\nby (job, namespace, verticalpodautoscaler, container, resource)\n",
                "format": "table",
                "instant": true,
                "legendFormat": "Requests"
@@ -329,7 +329,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  label_replace(\n    max(\n      kube_pod_container_resource_limits{\n        cluster=\"$cluster\",\n        job=~\"$job\",\n        namespace=~\"$namespace\",\n        resource=\"memory\"\n      }\n    ) by (job, namespace, pod, container, resource),\n    \"verticalpodautoscaler\", \"$1\", \"pod\", \"^(.*?)(?:-[a-f0-9]{8,10}-[a-z0-9]{5}|-[0-9]+|-[a-z0-9]{5,16})$\"\n  )\n  + on(job, namespace, container, resource, verticalpodautoscaler) group_left()\n  0 *\n  max(\n    kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n      cluster=\"$cluster\",\n      job=~\"$job\",\n      namespace=~\"$namespace\",\n      resource=\"memory\"\n    }\n  ) by (job, namespace, verticalpodautoscaler, container, resource)\n)\nby (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  label_replace(\n    max(\n      kube_pod_container_resource_limits{\n        cluster=~\"$cluster\",\n        job=~\"$job\",\n        namespace=~\"$namespace\",\n        resource=\"memory\"\n      }\n    ) by (job, namespace, pod, container, resource),\n    \"verticalpodautoscaler\", \"$1\", \"pod\", \"^(.*?)(?:-[a-f0-9]{8,10}-[a-z0-9]{5}|-[0-9]+|-[a-z0-9]{5,16})$\"\n  )\n  + on(job, namespace, container, resource, verticalpodautoscaler) group_left()\n  0 *\n  max(\n    kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n      cluster=~\"$cluster\",\n      job=~\"$job\",\n      namespace=~\"$namespace\",\n      resource=\"memory\"\n    }\n  ) by (job, namespace, verticalpodautoscaler, container, resource)\n)\nby (job, namespace, verticalpodautoscaler, container, resource)\n",
                "format": "table",
                "instant": true,
                "legendFormat": "Limits"
@@ -339,7 +339,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound{\n    cluster=\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
                "format": "table",
                "instant": true,
                "legendFormat": "Lower Bound"
@@ -349,7 +349,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n    cluster=\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
                "format": "table",
                "instant": true,
                "legendFormat": "Target"
@@ -359,7 +359,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound{\n    cluster=\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
                "format": "table",
                "instant": true,
                "legendFormat": "Upper Bound"
@@ -379,14 +379,14 @@
                      "namespace": true
                   },
                   "indexByName": {
-                     "Value #A": 3,
-                     "Value #B": 4,
-                     "Value #C": 5,
-                     "Value #D": 6,
-                     "Value #E": 7,
-                     "container": 1,
-                     "resource": 2,
-                     "verticalpodautoscaler": 0
+                     "Value #A": 4,
+                     "Value #B": 5,
+                     "Value #C": 6,
+                     "Value #D": 7,
+                     "Value #E": 8,
+                     "container": 2,
+                     "resource": 3,
+                     "verticalpodautoscaler": 1
                   },
                   "renameByName": {
                      "Value #A": "Requests",
@@ -455,7 +455,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n    cluster=\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
                "legendFormat": "CPU Requests"
             },
             {
@@ -463,7 +463,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n    cluster=\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
                "legendFormat": "CPU Limits"
             }
          ],
@@ -533,7 +533,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound{\n    cluster=\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
                "legendFormat": "CPU Requests"
             },
             {
@@ -541,7 +541,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound{\n    cluster=\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
                "legendFormat": "CPU Limits"
             }
          ],
@@ -587,7 +587,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n    cluster=\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
                "legendFormat": "Memory Requests"
             },
             {
@@ -595,7 +595,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n    cluster=\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
                "legendFormat": "Memory Limits"
             }
          ],
@@ -665,7 +665,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound{\n    cluster=\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
                "legendFormat": "Memory Requests"
             },
             {
@@ -673,7 +673,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound{\n    cluster=\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
                "legendFormat": "Memory Limits"
             }
          ],
@@ -725,48 +725,48 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound{\n    cluster=\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
-               "legendFormat": "{{ container }} - Lower Bound"
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "legendFormat": "Lower Bound"
             },
             {
                "datasource": {
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n    cluster=\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
-               "legendFormat": "{{ container }} - Target"
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "legendFormat": "Target"
             },
             {
                "datasource": {
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound{\n    cluster=\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
-               "legendFormat": "{{ container }} - Upper Bound"
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "legendFormat": "Upper Bound"
             },
             {
                "datasource": {
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "avg(\n  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{\n    cluster=\"$cluster\",\n    namespace=~\"$namespace\",\n    pod=~\"$vpa-.*\",\n    container=~\"$container\",\n    container!=\"\"\n  }\n) by (container)\n",
-               "legendFormat": "{{ container }} - Usage"
+               "expr": "avg(\n  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{\n    cluster=~\"$cluster\",\n    namespace=~\"$namespace\",\n    pod=~\"$vpa-.*\",\n    container=~\"$container\",\n    container!=\"\"\n  }\n) by (container)\n",
+               "legendFormat": "Usage"
             },
             {
                "datasource": {
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_pod_container_resource_requests{\n    cluster=\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    pod=~\"$vpa-.*\",\n    resource=~\"cpu\",\n    container=~\"$container\"\n  }\n) by (container)\n",
-               "legendFormat": "{{ container }} - Requests"
+               "expr": "max(\n  kube_pod_container_resource_requests{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    pod=~\"$vpa-.*\",\n    resource=~\"cpu\",\n    container=~\"$container\"\n  }\n) by (container)\n",
+               "legendFormat": "Requests"
             },
             {
                "datasource": {
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_pod_container_resource_limits{\n    cluster=\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    pod=~\"$vpa-.*\",\n    resource=~\"cpu\",\n    container=~\"$container\"\n  }\n) by (container)\n",
-               "legendFormat": "{{ container }} - Limits"
+               "expr": "max(\n  kube_pod_container_resource_limits{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    pod=~\"$vpa-.*\",\n    resource=~\"cpu\",\n    container=~\"$container\"\n  }\n) by (container)\n",
+               "legendFormat": "Limits"
             }
          ],
          "title": "VPA CPU Recommendations Over Time",
@@ -817,48 +817,48 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound{\n    cluster=\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
-               "legendFormat": "{{ container }} - Lower Bound"
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "legendFormat": "Lower Bound"
             },
             {
                "datasource": {
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n    cluster=\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
-               "legendFormat": "{{ container }} - Target"
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "legendFormat": "Target"
             },
             {
                "datasource": {
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound{\n    cluster=\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
-               "legendFormat": "{{ container }} - Upper Bound"
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "legendFormat": "Upper Bound"
             },
             {
                "datasource": {
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "avg(\n  container_memory_working_set_bytes{\n    cluster=\"$cluster\",\n    namespace=~\"$namespace\",\n    pod=~\"$vpa-.*\",\n    container=~\"$container\"\n  }\n) by (container)\n",
-               "legendFormat": "{{ container }} - Usage"
+               "expr": "avg(\n  container_memory_working_set_bytes{\n    cluster=~\"$cluster\",\n    namespace=~\"$namespace\",\n    pod=~\"$vpa-.*\",\n    container=~\"$container\"\n  }\n) by (container)\n",
+               "legendFormat": "Usage"
             },
             {
                "datasource": {
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_pod_container_resource_requests{\n    cluster=\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    pod=~\"$vpa-.*\",\n    resource=~\"memory\",\n    container=~\"$container\"\n  }\n) by (container)\n",
-               "legendFormat": "{{ container }} - Requests"
+               "expr": "max(\n  kube_pod_container_resource_requests{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    pod=~\"$vpa-.*\",\n    resource=~\"memory\",\n    container=~\"$container\"\n  }\n) by (container)\n",
+               "legendFormat": "Requests"
             },
             {
                "datasource": {
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_pod_container_resource_limits{\n    cluster=\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    pod=~\"$vpa-.*\",\n    resource=~\"memory\",\n    container=~\"$container\"\n  }\n) by (container)\n",
-               "legendFormat": "{{ container }} - Limits"
+               "expr": "max(\n  kube_pod_container_resource_limits{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    pod=~\"$vpa-.*\",\n    resource=~\"memory\",\n    container=~\"$container\"\n  }\n) by (container)\n",
+               "legendFormat": "Limits"
             }
          ],
          "title": "VPA Memory Recommendations Over Time",
@@ -905,7 +905,7 @@
             },
             "label": "Job",
             "name": "job",
-            "query": "label_values(kube_customresource_verticalpodautoscaler_labels{cluster=\"$cluster\"}, job)",
+            "query": "label_values(kube_customresource_verticalpodautoscaler_labels{cluster=~\"$cluster\"}, job)",
             "refresh": 2,
             "sort": 1,
             "type": "query"
@@ -918,7 +918,7 @@
             "label": "Namespace",
             "multi": true,
             "name": "namespace",
-            "query": "label_values(kube_customresource_verticalpodautoscaler_labels{cluster=\"$cluster\", job=~\"$job\"}, namespace)",
+            "query": "label_values(kube_customresource_verticalpodautoscaler_labels{cluster=~\"$cluster\", job=~\"$job\"}, namespace)",
             "refresh": 2,
             "sort": 1,
             "type": "query"
@@ -930,7 +930,7 @@
             },
             "label": "VPA Pod Autoscaler",
             "name": "vpa",
-            "query": "label_values(kube_customresource_verticalpodautoscaler_labels{cluster=\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"}, verticalpodautoscaler)",
+            "query": "label_values(kube_customresource_verticalpodautoscaler_labels{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\"}, verticalpodautoscaler)",
             "refresh": 2,
             "sort": 1,
             "type": "query"
@@ -944,7 +944,7 @@
             "label": "Container",
             "multi": true,
             "name": "container",
-            "query": "label_values(kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{cluster=\"$cluster\", job=~\"$job\", namespace=~\"$namespace\", verticalpodautoscaler=~\"$vpa\"}, container)",
+            "query": "label_values(kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{cluster=~\"$cluster\", job=~\"$job\", namespace=~\"$namespace\", verticalpodautoscaler=~\"$vpa\"}, container)",
             "refresh": 2,
             "sort": 1,
             "type": "query"

--- a/dashboards_out/kubernetes-autoscaling-mixin-vpa.json
+++ b/dashboards_out/kubernetes-autoscaling-mixin-vpa.json
@@ -133,7 +133,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  label_replace(\n    max(\n      kube_pod_container_resource_requests{\n        cluster=~\"$cluster\",\n        job=~\"$job\",\n        namespace=~\"$namespace\",\n        resource=\"cpu\"\n      }\n    ) by (job, namespace, pod, container, resource),\n    \"verticalpodautoscaler\", \"$1\", \"pod\", \"^(.*?)(?:-[a-f0-9]{8,10}-[a-z0-9]{5}|-[0-9]+|-[a-z0-9]{5,16})$\"\n  )\n  + on(job, namespace, container, resource, verticalpodautoscaler) group_left()\n  0 *\n  max(\n    kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n      cluster=~\"$cluster\",\n      job=~\"$job\",\n      namespace=~\"$namespace\",\n      resource=\"cpu\"\n    }\n  ) by (job, namespace, verticalpodautoscaler, container, resource)\n)\nby (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  label_replace(\n    max(\n      kube_pod_container_resource_requests{\n        cluster=~\"$cluster\",\n        job=~\"$job\",\n        namespace=~\"$namespace\",\n        resource=\"cpu\"\n      }\n    ) by (job, cluster, namespace, pod, container, resource),\n    \"verticalpodautoscaler\", \"$1\", \"pod\", \"^(.*?)(?:-[a-f0-9]{8,10}-[a-z0-9]{5}|-[0-9]+|-[a-z0-9]{5,16})$\"\n  )\n  + on(job, cluster, namespace, container, resource, verticalpodautoscaler) group_left()\n  0 *\n  max(\n    kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n      cluster=~\"$cluster\",\n      job=~\"$job\",\n      namespace=~\"$namespace\",\n      resource=\"cpu\"\n    }\n  ) by (job, cluster, namespace, verticalpodautoscaler, container, resource)\n)\nby (job, cluster, namespace, verticalpodautoscaler, container, resource)\n",
                "format": "table",
                "instant": true,
                "legendFormat": "Requests"
@@ -143,7 +143,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  label_replace(\n    max(\n      kube_pod_container_resource_limits{\n        cluster=~\"$cluster\",\n        job=~\"$job\",\n        namespace=~\"$namespace\",\n        resource=\"cpu\"\n      }\n    ) by (job, namespace, pod, container, resource),\n    \"verticalpodautoscaler\", \"$1\", \"pod\", \"^(.*?)(?:-[a-f0-9]{8,10}-[a-z0-9]{5}|-[0-9]+|-[a-z0-9]{5,16})$\"\n  )\n  + on(job, namespace, container, resource, verticalpodautoscaler) group_left()\n  0 *\n  max(\n    kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n      cluster=~\"$cluster\",\n      job=~\"$job\",\n      namespace=~\"$namespace\",\n      resource=\"cpu\"\n    }\n  ) by (job, namespace, verticalpodautoscaler, container, resource)\n)\nby (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  label_replace(\n    max(\n      kube_pod_container_resource_limits{\n        cluster=~\"$cluster\",\n        job=~\"$job\",\n        namespace=~\"$namespace\",\n        resource=\"cpu\"\n      }\n    ) by (job, cluster, namespace, pod, container, resource),\n    \"verticalpodautoscaler\", \"$1\", \"pod\", \"^(.*?)(?:-[a-f0-9]{8,10}-[a-z0-9]{5}|-[0-9]+|-[a-z0-9]{5,16})$\"\n  )\n  + on(job, cluster, namespace, container, resource, verticalpodautoscaler) group_left()\n  0 *\n  max(\n    kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n      cluster=~\"$cluster\",\n      job=~\"$job\",\n      namespace=~\"$namespace\",\n      resource=\"cpu\"\n    }\n  ) by (job, cluster, namespace, verticalpodautoscaler, container, resource)\n)\nby (job, cluster, namespace, verticalpodautoscaler, container, resource)\n",
                "format": "table",
                "instant": true,
                "legendFormat": "Limits"
@@ -153,7 +153,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\"\n  }\n) by (job, cluster, namespace, verticalpodautoscaler, container, resource)\n",
                "format": "table",
                "instant": true,
                "legendFormat": "Lower Bound"
@@ -163,7 +163,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\"\n  }\n) by (job, cluster, namespace, verticalpodautoscaler, container, resource)\n",
                "format": "table",
                "instant": true,
                "legendFormat": "Target"
@@ -173,7 +173,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\"\n  }\n) by (job, cluster, namespace, verticalpodautoscaler, container, resource)\n",
                "format": "table",
                "instant": true,
                "legendFormat": "Upper Bound"
@@ -319,7 +319,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  label_replace(\n    max(\n      kube_pod_container_resource_requests{\n        cluster=~\"$cluster\",\n        job=~\"$job\",\n        namespace=~\"$namespace\",\n        resource=\"memory\"\n      }\n    ) by (job, namespace, pod, container, resource),\n    \"verticalpodautoscaler\", \"$1\", \"pod\", \"^(.*?)(?:-[a-f0-9]{8,10}-[a-z0-9]{5}|-[0-9]+|-[a-z0-9]{5,16})$\"\n  )\n  + on(job, namespace, container, resource, verticalpodautoscaler) group_left()\n  0 *\n  max(\n    kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n      cluster=~\"$cluster\",\n      job=~\"$job\",\n      namespace=~\"$namespace\",\n      resource=\"memory\"\n    }\n  ) by (job, namespace, verticalpodautoscaler, container, resource)\n)\nby (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  label_replace(\n    max(\n      kube_pod_container_resource_requests{\n        cluster=~\"$cluster\",\n        job=~\"$job\",\n        namespace=~\"$namespace\",\n        resource=\"memory\"\n      }\n    ) by (job, cluster, namespace, pod, container, resource),\n    \"verticalpodautoscaler\", \"$1\", \"pod\", \"^(.*?)(?:-[a-f0-9]{8,10}-[a-z0-9]{5}|-[0-9]+|-[a-z0-9]{5,16})$\"\n  )\n  + on(job, cluster, namespace, container, resource, verticalpodautoscaler) group_left()\n  0 *\n  max(\n    kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n      cluster=~\"$cluster\",\n      job=~\"$job\",\n      namespace=~\"$namespace\",\n      resource=\"memory\"\n    }\n  ) by (job, cluster, namespace, verticalpodautoscaler, container, resource)\n)\nby (job, cluster, namespace, verticalpodautoscaler, container, resource)\n",
                "format": "table",
                "instant": true,
                "legendFormat": "Requests"
@@ -329,7 +329,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  label_replace(\n    max(\n      kube_pod_container_resource_limits{\n        cluster=~\"$cluster\",\n        job=~\"$job\",\n        namespace=~\"$namespace\",\n        resource=\"memory\"\n      }\n    ) by (job, namespace, pod, container, resource),\n    \"verticalpodautoscaler\", \"$1\", \"pod\", \"^(.*?)(?:-[a-f0-9]{8,10}-[a-z0-9]{5}|-[0-9]+|-[a-z0-9]{5,16})$\"\n  )\n  + on(job, namespace, container, resource, verticalpodautoscaler) group_left()\n  0 *\n  max(\n    kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n      cluster=~\"$cluster\",\n      job=~\"$job\",\n      namespace=~\"$namespace\",\n      resource=\"memory\"\n    }\n  ) by (job, namespace, verticalpodautoscaler, container, resource)\n)\nby (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  label_replace(\n    max(\n      kube_pod_container_resource_limits{\n        cluster=~\"$cluster\",\n        job=~\"$job\",\n        namespace=~\"$namespace\",\n        resource=\"memory\"\n      }\n    ) by (job, cluster, namespace, pod, container, resource),\n    \"verticalpodautoscaler\", \"$1\", \"pod\", \"^(.*?)(?:-[a-f0-9]{8,10}-[a-z0-9]{5}|-[0-9]+|-[a-z0-9]{5,16})$\"\n  )\n  + on(job, cluster, namespace, container, resource, verticalpodautoscaler) group_left()\n  0 *\n  max(\n    kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n      cluster=~\"$cluster\",\n      job=~\"$job\",\n      namespace=~\"$namespace\",\n      resource=\"memory\"\n    }\n  ) by (job, cluster, namespace, verticalpodautoscaler, container, resource)\n)\nby (job, cluster, namespace, verticalpodautoscaler, container, resource)\n",
                "format": "table",
                "instant": true,
                "legendFormat": "Limits"
@@ -339,7 +339,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\"\n  }\n) by (job, cluster, namespace, verticalpodautoscaler, container, resource)\n",
                "format": "table",
                "instant": true,
                "legendFormat": "Lower Bound"
@@ -349,7 +349,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\"\n  }\n) by (job, cluster, namespace, verticalpodautoscaler, container, resource)\n",
                "format": "table",
                "instant": true,
                "legendFormat": "Target"
@@ -359,7 +359,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\"\n  }\n) by (job, cluster, namespace, verticalpodautoscaler, container, resource)\n",
                "format": "table",
                "instant": true,
                "legendFormat": "Upper Bound"
@@ -455,7 +455,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, cluster, namespace, verticalpodautoscaler, container, resource)\n",
                "legendFormat": "CPU Requests"
             },
             {
@@ -463,7 +463,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, cluster, namespace, verticalpodautoscaler, container, resource)\n",
                "legendFormat": "CPU Limits"
             }
          ],
@@ -533,7 +533,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, cluster, namespace, verticalpodautoscaler, container, resource)\n",
                "legendFormat": "CPU Requests"
             },
             {
@@ -541,7 +541,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, cluster, namespace, verticalpodautoscaler, container, resource)\n",
                "legendFormat": "CPU Limits"
             }
          ],
@@ -587,7 +587,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, cluster, namespace, verticalpodautoscaler, container, resource)\n",
                "legendFormat": "Memory Requests"
             },
             {
@@ -595,7 +595,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, cluster, namespace, verticalpodautoscaler, container, resource)\n",
                "legendFormat": "Memory Limits"
             }
          ],
@@ -665,7 +665,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, cluster, namespace, verticalpodautoscaler, container, resource)\n",
                "legendFormat": "Memory Requests"
             },
             {
@@ -673,7 +673,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, cluster, namespace, verticalpodautoscaler, container, resource)\n",
                "legendFormat": "Memory Limits"
             }
          ],
@@ -725,7 +725,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, cluster, namespace, verticalpodautoscaler, container, resource)\n",
                "legendFormat": "Lower Bound"
             },
             {
@@ -733,7 +733,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, cluster, namespace, verticalpodautoscaler, container, resource)\n",
                "legendFormat": "Target"
             },
             {
@@ -741,7 +741,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"cpu\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, cluster, namespace, verticalpodautoscaler, container, resource)\n",
                "legendFormat": "Upper Bound"
             },
             {
@@ -749,7 +749,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "avg(\n  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{\n    cluster=~\"$cluster\",\n    namespace=~\"$namespace\",\n    pod=~\"$vpa-.*\",\n    container=~\"$container\",\n    container!=\"\"\n  }\n) by (container)\n",
+               "expr": "avg(\n  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{\n    cluster=~\"$cluster\",\n    namespace=~\"$namespace\",\n    pod=~\"$vpa-.*\",\n    container=~\"$container\",\n    container!=\"\"\n  }\n) by (cluster, container)\n",
                "legendFormat": "Usage"
             },
             {
@@ -757,7 +757,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_pod_container_resource_requests{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    pod=~\"$vpa-.*\",\n    resource=~\"cpu\",\n    container=~\"$container\"\n  }\n) by (container)\n",
+               "expr": "max(\n  kube_pod_container_resource_requests{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    pod=~\"$vpa-.*\",\n    resource=~\"cpu\",\n    container=~\"$container\"\n  }\n) by (cluster, container)\n",
                "legendFormat": "Requests"
             },
             {
@@ -765,7 +765,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_pod_container_resource_limits{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    pod=~\"$vpa-.*\",\n    resource=~\"cpu\",\n    container=~\"$container\"\n  }\n) by (container)\n",
+               "expr": "max(\n  kube_pod_container_resource_limits{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    pod=~\"$vpa-.*\",\n    resource=~\"cpu\",\n    container=~\"$container\"\n  }\n) by (cluster, container)\n",
                "legendFormat": "Limits"
             }
          ],
@@ -817,7 +817,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, cluster, namespace, verticalpodautoscaler, container, resource)\n",
                "legendFormat": "Lower Bound"
             },
             {
@@ -825,7 +825,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, cluster, namespace, verticalpodautoscaler, container, resource)\n",
                "legendFormat": "Target"
             },
             {
@@ -833,7 +833,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, namespace, verticalpodautoscaler, container, resource)\n",
+               "expr": "max(\n  kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    resource=\"memory\",\n    verticalpodautoscaler=~\"$vpa\",\n    container=~\"$container\"\n  }\n) by (job, cluster, namespace, verticalpodautoscaler, container, resource)\n",
                "legendFormat": "Upper Bound"
             },
             {
@@ -841,7 +841,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "avg(\n  container_memory_working_set_bytes{\n    cluster=~\"$cluster\",\n    namespace=~\"$namespace\",\n    pod=~\"$vpa-.*\",\n    container=~\"$container\"\n  }\n) by (container)\n",
+               "expr": "avg(\n  container_memory_working_set_bytes{\n    cluster=~\"$cluster\",\n    namespace=~\"$namespace\",\n    pod=~\"$vpa-.*\",\n    container=~\"$container\"\n  }\n) by (cluster, container)\n",
                "legendFormat": "Usage"
             },
             {
@@ -849,7 +849,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_pod_container_resource_requests{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    pod=~\"$vpa-.*\",\n    resource=~\"memory\",\n    container=~\"$container\"\n  }\n) by (container)\n",
+               "expr": "max(\n  kube_pod_container_resource_requests{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    pod=~\"$vpa-.*\",\n    resource=~\"memory\",\n    container=~\"$container\"\n  }\n) by (cluster, container)\n",
                "legendFormat": "Requests"
             },
             {
@@ -857,7 +857,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max(\n  kube_pod_container_resource_limits{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    pod=~\"$vpa-.*\",\n    resource=~\"memory\",\n    container=~\"$container\"\n  }\n) by (container)\n",
+               "expr": "max(\n  kube_pod_container_resource_limits{\n    cluster=~\"$cluster\",\n    job=~\"$job\",\n    namespace=~\"$namespace\",\n    pod=~\"$vpa-.*\",\n    resource=~\"memory\",\n    container=~\"$container\"\n  }\n) by (cluster, container)\n",
                "legendFormat": "Limits"
             }
          ],


### PR DESCRIPTION
Adding a feature to allow aggregating VPA metrics across many clusters.
This can be really useful when trying to compare VPA usage across a set of clusters.

This is added behind a feature flag.
If the feature flag is enabled:

1. add `by (cluster)` to namespace queries
2. add `{{cluster}}` to VPA queries