### PR TITLE
fix: Use node limits as variable

### DIFF
--- a/dashboards/karpenter/karpenter-activity.libsonnet
+++ b/dashboards/karpenter/karpenter-activity.libsonnet
@@ -66,7 +66,7 @@ local tsLegend = tsOptions.legend;
     local nodePoolVariable =
       query.new(
         'nodepool',
-        'label_values(karpenter_nodepools_allowed_disruptions{%(clusterLabel)s="$cluster", job=~"$job"}, nodepool)' % $._config,
+        'label_values(karpenter_nodepools_limit{%(clusterLabel)s="$cluster", job=~"$job"}, nodepool)' % $._config,
       ) +
       query.withDatasourceFromVariable(datasourceVariable) +
       query.withSort(1) +

--- a/dashboards/karpenter/karpenter-overview.libsonnet
+++ b/dashboards/karpenter/karpenter-overview.libsonnet
@@ -312,7 +312,7 @@ local pieQueryOptions = pieChartPanel.queryOptions;
     local karpenterNodePoolsQuery = |||
       count(
         count(
-          karpenter_nodepools_allowed_disruptions{
+          karpenter_nodepools_limit{
             %(clusterLabel)s="$cluster",
             job=~"$job",
           }

--- a/dashboards_out/kubernetes-autoscaling-mixin-karpenter-act.json
+++ b/dashboards_out/kubernetes-autoscaling-mixin-karpenter-act.json
@@ -485,7 +485,7 @@
             "label": "Node Pool",
             "multi": true,
             "name": "nodepool",
-            "query": "label_values(karpenter_nodepools_allowed_disruptions{cluster=\"$cluster\", job=~\"$job\"}, nodepool)",
+            "query": "label_values(karpenter_nodepools_limit{cluster=\"$cluster\", job=~\"$job\"}, nodepool)",
             "refresh": 2,
             "sort": 1,
             "type": "query"

--- a/dashboards_out/kubernetes-autoscaling-mixin-karpenter-over.json
+++ b/dashboards_out/kubernetes-autoscaling-mixin-karpenter-over.json
@@ -206,7 +206,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "count(\n  count(\n    karpenter_nodepools_allowed_disruptions{\n      cluster=\"$cluster\",\n      job=~\"$job\",\n    }\n  ) by (nodepool)\n)\n"
+               "expr": "count(\n  count(\n    karpenter_nodepools_limit{\n      cluster=\"$cluster\",\n      job=~\"$job\",\n    }\n  ) by (nodepool)\n)\n"
             }
          ],
          "title": "Node Pools",


### PR DESCRIPTION
The disruptions allowed always return high values.
