### PR TITLE
fix(karpenter): unhide cluster dashboard var so Job populates on multi-cluster

### DIFF
--- a/dashboards/karpenter/util.libsonnet
+++ b/dashboards/karpenter/util.libsonnet
@@ -167,19 +167,19 @@ local query = variable.query;
       query.withDatasourceFromVariable(this.datasource) +
       query.queryTypes.withLabelValues(
         config.clusterLabel,
-        'kube_pod_info{%(kubeStateMetricsSelector)s}' % config,
+        'karpenter_nodes_allocatable',
       ) +
       query.generalOptions.withLabel('Cluster') +
       query.refresh.onLoad() +
       query.refresh.onTime() +
       query.withSort() +
+      query.generalOptions.showOnDashboard.withLabelAndValue() +
       (
         if config.showMultiCluster
         then
-          query.generalOptions.showOnDashboard.withLabelAndValue() +
           query.selectionOptions.withMulti(value=config.multiClusterAllowsMultipleSelection) +
           query.selectionOptions.withIncludeAll(value=config.multiClusterIncludeAllValue)
-        else query.generalOptions.showOnDashboard.withNothing()
+        else {}
       ),
 
     job:

--- a/dashboards_out/kubernetes-autoscaling-mixin-karpenter-act.json
+++ b/dashboards_out/kubernetes-autoscaling-mixin-karpenter-act.json
@@ -838,10 +838,10 @@
                "type": "prometheus",
                "uid": "${datasource}"
             },
-            "hide": 2,
+            "hide": 0,
             "label": "Cluster",
             "name": "cluster",
-            "query": "label_values(kube_pod_info{job=~\"kube-state-metrics\"}, cluster)",
+            "query": "label_values(karpenter_nodes_allocatable, cluster)",
             "refresh": 2,
             "sort": 1,
             "type": "query"

--- a/dashboards_out/kubernetes-autoscaling-mixin-karpenter-costs.json
+++ b/dashboards_out/kubernetes-autoscaling-mixin-karpenter-costs.json
@@ -766,10 +766,10 @@
                "type": "prometheus",
                "uid": "${datasource}"
             },
-            "hide": 2,
+            "hide": 0,
             "label": "Cluster",
             "name": "cluster",
-            "query": "label_values(kube_pod_info{job=~\"kube-state-metrics\"}, cluster)",
+            "query": "label_values(karpenter_nodes_allocatable, cluster)",
             "refresh": 2,
             "sort": 1,
             "type": "query"

--- a/dashboards_out/kubernetes-autoscaling-mixin-karpenter-over.json
+++ b/dashboards_out/kubernetes-autoscaling-mixin-karpenter-over.json
@@ -1736,10 +1736,10 @@
                "type": "prometheus",
                "uid": "${datasource}"
             },
-            "hide": 2,
+            "hide": 0,
             "label": "Cluster",
             "name": "cluster",
-            "query": "label_values(kube_pod_info{job=~\"kube-state-metrics\"}, cluster)",
+            "query": "label_values(karpenter_nodes_allocatable, cluster)",
             "refresh": 2,
             "sort": 1,
             "type": "query"

--- a/dashboards_out/kubernetes-autoscaling-mixin-karpenter-perf.json
+++ b/dashboards_out/kubernetes-autoscaling-mixin-karpenter-perf.json
@@ -1044,10 +1044,10 @@
                "type": "prometheus",
                "uid": "${datasource}"
             },
-            "hide": 2,
+            "hide": 0,
             "label": "Cluster",
             "name": "cluster",
-            "query": "label_values(kube_pod_info{job=~\"kube-state-metrics\"}, cluster)",
+            "query": "label_values(karpenter_nodes_allocatable, cluster)",
             "refresh": 2,
             "sort": 1,
             "type": "query"


### PR DESCRIPTION
## Problem

Karpenter dashboards imported from grafana.com (or generated with the default `showMultiCluster: false`) show empty Job dropdowns and blank panels in multi-cluster Prometheus/VictoriaMetrics.

Root cause: the `cluster` template variable is hidden via `withNothing()` when `showMultiCluster` is false, but Job and the other cascading variables still filter on `cluster="$cluster"`. With no selectable cluster, Job never populates and queries return nothing.

Enabling `showMultiCluster` in mixin config works for vendored installs, but is not available for the published grafana.com JSON.

Additionally, sourcing `cluster` from `kube_pod_info` lists every cluster with kube-state-metrics, including ones that have no Karpenter metrics — so even after unhiding, users can pick a cluster where Job stays empty.

Related: #26 (closed by documenting/`showMultiCluster`; does not fix the default / grafana.com boards).

## Changes

- Always show the `cluster` template variable in Karpenter dashboards (`dashboards/karpenter/util.libsonnet`)
- Query `cluster` from `karpenter_nodes_allocatable` instead of `kube_pod_info`
- Regenerate `dashboards_out/` via `make generate` / `make fmt`

## Test plan

- [ ] `make generate && make fmt` clean
- [ ] CI green
- [ ] Import Overview / Activity / Performance / Costs with `showMultiCluster: false`
- [ ] Confirm `cluster` is visible and Job populates after selecting a cluster with Karpenter metrics
- [ ] Confirm single-cluster environments still behave sensibly